### PR TITLE
Add cargo-husky for precommit hooks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,4 +1,14 @@
 [[package]]
+name = "cargo-husky"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "rust-ci-example"
 version = "0.1.1-alpha.0"
+dependencies = [
+ "cargo-husky 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
+[metadata]
+"checksum cargo-husky 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "91ee33f8f39e4b469dfcab5f86c2572355965b49329ff8a665b530cc52c1dfa3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,9 @@ authors = ["Walfie <walfington@gmail.com>"]
 publish = false
 
 [dependencies]
+
+[dev-dependencies.cargo-husky]
+version = "1.2.0"
+default-features = false
+features = ["precommit-hook", "run-cargo-fmt", "run-cargo-test"]
+


### PR DESCRIPTION
On running `cargo test`, a precommit hook is installed which will check syntax
and tests before the commit is added to the git history.