### PR TITLE
Add CI template from japaric/trust

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,71 @@
+# Based on the "trust" template v0.1.2
+# https://github.com/japaric/trust/tree/v0.1.2
+
+environment:
+  global:
+    RUST_VERSION: stable
+    CRATE_NAME: rust-ci-example
+    EXECUTABLE_NAME: rust-ci-example
+
+  matrix:
+    # MinGW
+    - TARGET: x86_64-pc-windows-gnu
+
+    # MSVC
+    - TARGET: x86_64-pc-windows-msvc
+
+install:
+  - ps: >-
+      If ($Env:TARGET -eq 'x86_64-pc-windows-gnu') {
+        $Env:PATH += ';C:\msys64\mingw64\bin'
+      } ElseIf ($Env:TARGET -eq 'i686-pc-windows-gnu') {
+        $Env:PATH += ';C:\msys64\mingw32\bin'
+      }
+  - curl -sSf -o rustup-init.exe https://win.rustup.rs/
+  - rustup-init.exe -y --default-host %TARGET% --default-toolchain %RUST_VERSION%
+  - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
+  - rustc -Vv
+  - cargo -V
+
+test_script:
+  # we don't run the "test phase" when doing deploys
+  - if [%APPVEYOR_REPO_TAG%]==[false] (
+      cargo build --target %TARGET% &&
+      cargo test --target %TARGET%
+    )
+
+before_deploy:
+  - cargo rustc --target %TARGET% --release --bin %EXECUTABLE_NAME% -- -C lto
+  - ps: ci\before_deploy.ps1
+
+deploy:
+  artifact: /.*\.zip/
+  # `auth_token.secure` is obtained as follows:
+  # - Create a `public_repo` GitHub token. Go to: https://github.com/settings/tokens/new
+  # - Encrypt it. Go to https://ci.appveyor.com/tools/encrypt
+  # - Paste the output down here
+  auth_token:
+    secure: JEV3VG2FaCbnq7ewxXrjepwrMSRRIpJYsz3jEg/cnmpTXfMx1moFGHbnbUfttxwx
+  description: ''
+  on:
+    RUST_VERSION: stable
+    appveyor_repo_tag: true
+  provider: GitHub
+
+cache:
+  - C:\Users\appveyor\.cargo\registry
+  - target
+
+branches:
+  only:
+    # Release tags (e.g. "v1.2.3" or "1.2.3")
+    - /^v?\d+\.\d+\.\d+.*$/
+    - master
+
+notifications:
+  - provider: Email
+    on_build_success: false
+
+# Building is done in the test phase, so we disable Appveyor's build phase.
+build: false
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,70 @@
-language: rust
+# Based on the "trust" template v0.1.2
+# https://github.com/japaric/trust/tree/v0.1.2
 
-rust:
-  - stable
-  - beta
-  - nightly
+dist: trusty
+language: rust
+services: docker
+sudo: required
+
+env:
+  global:
+    - CRATE_NAME=rust-ci-example
+    - EXECUTABLE_NAME=rust-ci-example
 
 matrix:
-  allow_failures:
-    - rust: nightly
-  fast_finish: true
+  include:
+    # Linux
+    - env: TARGET=x86_64-unknown-linux-musl
 
-branches:
-  only:
-    # E.g., `v1.2.3`
-    - /^v\d+\.\d+\.\d+.*$/
-    - master
+    # OSX
+    - env: TARGET=x86_64-apple-darwin
+      os: osx
 
-before_script:
+    # Windows
+    - env: TARGET=x86_64-pc-windows-gnu
+
+before_install:
+  - set -e
+  - rustup self update
   - rustup component add rustfmt-preview
+
+install:
+  - sh ci/install.sh
+  - source ~/.cargo/env || true
+
 script:
-  - cargo fmt --all -- --check || travis_terminate 1
-  - cargo build --all --verbose || travis_terminate 1
-  - cargo test --all --verbose || travis_terminate 1
+  - bash ci/script.sh
+
+after_script: set +e
+
+before_deploy:
+  - sh ci/before_deploy.sh
+
+deploy:
+  # `api_key.secure` is obtained as follows:
+  # - Create a `public_repo` GitHub token. Go to: https://github.com/settings/tokens/new
+  # - Encrypt it: `travis encrypt 0123456789012345678901234567890123456789
+  # - Paste the output down here
+  api_key:
+    secure: "eeqBueUP5FEHMGY8UhJZUTK06bie+qUy5LZPMLJYRzcH7/462q45TvUsc5FPrbUut6ADqhls8GKQ/kY8YkqsjShrq8RUsJjjS7AbqvSAa9lQ8Kv8Sto1ITyq/i3W4OidQkzbWmj2AMRaBGR+SKXEAQToyWbYW79CuQBuaIztY9S/3YtvGFG7kvJxLJrQYPa/gnlZsg73PcWskaTNE1Gg7m2v2XY2dGS6ZsFsB8xrw9Ph868wFr8V2JPYOxuJRA4uK+KYFtJicDaYBVbAatb1Jzu62JYQru3ZYdn85qP1Q9150e0NrYgKaLMpGOuYxaxUw6oFCCNf479xn0UDg0XVZ72L/wS58WdVHxFMyvUWxC28hvIlN8ESKBoajgsbB4JmqRSel5entEBnDmWIeoB9Ncxm3lPJOiJEg1BcocdHdD3ROinhwEDsaHBeR+gXKk1t+gfkUWScoHU4qYYhS5hIjJEh9kRV9R5UGgPPOzb7Pd4a6+mldEPsCtx/yeTfHQlmjaxv7lOrgvZT5MfVFcjVaqvGDWvpbxcoqKW35m8cA85ZvMfGHMvFDG0K/uUeOWzTdkMJr7que4VK7+HDZWHEDzCojodwfh0nwHYv5ql6k4k+3SmBcQ9c0Mt5YPloJ+uw/CtANDqkcR4tI/12U96zWWuzGx9MHGnIV8R1PJdYjCk="
+  file_glob: true
+  file: $CRATE_NAME-$TRAVIS_TAG-$TARGET.*
+  on:
+    condition: $TRAVIS_RUST_VERSION = stable
+    tags: true
+  provider: releases
+  skip_cleanup: true
 
 cache: cargo
 before_cache:
   # Travis can't cache files that are not readable by "others"
   - chmod -R a+r $HOME/.cargo
+
+branches:
+  only:
+    # Release tags (e.g. "v1.2.3" or "1.2.3")
+    - /^v?\d+\.\d+\.\d+.*$/
+    - master
 
 notifications:
   email:

--- a/ci/before_deploy.ps1
+++ b/ci/before_deploy.ps1
@@ -1,0 +1,22 @@
+# This script takes care of packaging the build artifacts that will go in the
+# release zipfile
+
+$SRC_DIR = $PWD.Path
+$STAGE = [System.Guid]::NewGuid().ToString()
+
+Set-Location $ENV:Temp
+New-Item -Type Directory -Name $STAGE
+Set-Location $STAGE
+
+$ZIP = "$SRC_DIR\$($Env:CRATE_NAME)-$($Env:APPVEYOR_REPO_TAG_NAME)-$($Env:TARGET).zip"
+
+Copy-Item "$SRC_DIR\target\$($Env:TARGET)\release\$($Env:EXECUTABLE_NAME).exe" '.\'
+
+7z a "$ZIP" *
+
+Push-AppveyorArtifact "$ZIP"
+
+Remove-Item *.* -Force
+Set-Location ..
+Remove-Item $STAGE
+Set-Location $SRC_DIR

--- a/ci/before_deploy.sh
+++ b/ci/before_deploy.sh
@@ -1,0 +1,33 @@
+# This script takes care of building your crate and packaging it for release
+
+set -ex
+
+main() {
+    local src=$(pwd) \
+          stage=
+
+    case $TRAVIS_OS_NAME in
+        linux)
+            stage=$(mktemp -d)
+            ;;
+        osx)
+            stage=$(mktemp -d -t tmp)
+            ;;
+    esac
+
+    test -f Cargo.lock || cargo generate-lockfile
+
+    # Build artifacts
+    cross rustc --bin $EXECUTABLE_NAME --target $TARGET --release -- -C lto
+
+    # Package artifacts
+    cp target/$TARGET/release/$EXECUTABLE_NAME $stage/
+
+    cd $stage
+    tar czf $src/$CRATE_NAME-$TRAVIS_TAG-$TARGET.tar.gz *
+    cd $src
+
+    rm -rf $stage
+}
+
+main

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,0 +1,47 @@
+set -ex
+
+main() {
+    local target=
+    if [ $TRAVIS_OS_NAME = linux ]; then
+        target=x86_64-unknown-linux-musl
+        sort=sort
+    else
+        target=x86_64-apple-darwin
+        sort=gsort  # for `sort --sort-version`, from brew's coreutils.
+    fi
+
+    # Builds for iOS are done on OSX, but require the specific target to be
+    # installed.
+    case $TARGET in
+        aarch64-apple-ios)
+            rustup target install aarch64-apple-ios
+            ;;
+        armv7-apple-ios)
+            rustup target install armv7-apple-ios
+            ;;
+        armv7s-apple-ios)
+            rustup target install armv7s-apple-ios
+            ;;
+        i386-apple-ios)
+            rustup target install i386-apple-ios
+            ;;
+        x86_64-apple-ios)
+            rustup target install x86_64-apple-ios
+            ;;
+    esac
+
+    # This fetches latest stable release
+    local tag=$(git ls-remote --tags --refs --exit-code https://github.com/japaric/cross \
+                       | cut -d/ -f3 \
+                       | grep -E '^v[0.1.0-9.]+$' \
+                       | $sort --version-sort \
+                       | tail -n1)
+    curl -LSfs https://japaric.github.io/trust/install.sh | \
+        sh -s -- \
+           --force \
+           --git japaric/cross \
+           --tag $tag \
+           --target $target
+}
+
+main

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -1,0 +1,21 @@
+# This script takes care of testing your crate
+
+set -ex
+
+main() {
+    cargo fmt --all -- --check
+
+    cross build --all --target $TARGET
+
+    if [ ! -z $DISABLE_TESTS ]; then
+        return
+    fi
+
+    cross test --target $TARGET
+}
+
+# we don't run the "test phase" when doing deploys
+if [ -z $TRAVIS_TAG ]; then
+    main
+fi
+


### PR DESCRIPTION
Enables testing on multiple platforms, and uploading binaries to GitHub when
release tags are created.